### PR TITLE
Update banner image to cover background

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,7 +137,7 @@
   }
 
   #header-bottom-left {
-    background: url(%%BannerImage%%) center bottom;
+    background: url(%%BannerImage%%) center bottom / cover;
     height: 140px;
   }
 


### PR DESCRIPTION
When viewing r/Atlanta on a large screen the banner image gets repeated:

![screen shot 2014-05-06 at 1 23 25 pm](https://cloud.githubusercontent.com/assets/479121/2893102/c3644476-d544-11e3-9c73-76052ecabfb9.png)

I think it would look a bit nicer (imo) to have the image resize to cover the whole header background instead:

![screen shot 2014-05-06 at 1 24 20 pm](https://cloud.githubusercontent.com/assets/479121/2893176/b632e25c-d545-11e3-9580-6e43e10697fb.png)
